### PR TITLE
fix: log_* macros not working when called directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,41 +92,41 @@ macro_rules! log {
 #[macro_export]
 macro_rules! log_info {
     ($($arg:tt)*) => {
-        log!($crate::LogLevel::INFO, $($arg)*);
+        $crate::log!($crate::LogLevel::INFO, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! log_dbg {
     ($($arg:tt)*) => {
-        log!($crate::LogLevel::DEBUG, $($arg)*);
+        $crate::log!($crate::LogLevel::DEBUG, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! log_warn {
     ($($arg:tt)*) => {
-        log!($crate::LogLevel::WARN, $($arg)*);
+        $crate::log!($crate::LogLevel::WARN, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! log_err {
     ($($arg:tt)*) => {
-        log!($crate::LogLevel::ERROR, $($arg)*);
+        $crate::log!($crate::LogLevel::ERROR, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! log_success {
     ($($arg:tt)*) => {
-        log!($crate::LogLevel::SUCCESS, $($arg)*);
+        $crate::log!($crate::LogLevel::SUCCESS, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! log_fail {
     ($($arg:tt)*) => {
-        log!($crate::LogLevel::FAILURE, $($arg)*);
+        $crate::log!($crate::LogLevel::FAILURE, $($arg)*);
     };
 }


### PR DESCRIPTION
The log_info!, log_dbg!, etc. macros don't have a `$crate::` prefix, so calling them like
```rs
hackerlog::log_info!("Reticulating splines...");
```
fails with
```
error: cannot find macro `log` in this scope
```
because the log! macro isn't imported. Of course, you can just do `use hackerlog::*;` which is _fine_ but my coding style would rather not use star imports. Anyways, this PR adds `$crate::` to everything. Cheers